### PR TITLE
Advection fix

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ ARCH=--generate-code arch=compute_60,code=sm_60 \
 
 
 CUDA = nvcc 
-CUDAFLAGS = -O3 -g --std=c++17 -Wno-deprecated-gpu-targets $(ARCH)
+CUDAFLAGS = -O3 -g --std=c++17 -Wno-deprecated-gpu-targets $(ARCH) -lineinfo
 INCLUDE = -I./$(HEADER_DIR) -I$(CUDA_HOME)/include
 
 LIB = -L$(CUDA_HOME)/lib64 -lcudart -lcublas -lcusparse
@@ -27,7 +27,7 @@ LIB = -L$(CUDA_HOME)/lib64 -lcudart -lcublas -lcusparse
 COAG_HEADERS := coagulation.h kernels.h fragments.h size_grid.h integration.h
 COAG_HEADERS := $(addprefix coagulation/, $(COAG_HEADERS))
 
-HEADERS := grid.h field.h cuda_array.h reductions.h utils.h matrix_types.h \
+HEADERS := grid.h field.h cuda_array.h reductions.h utils.h matrix_types.h scan.h \
 	stellar_irradiation.h planck.h opacity.h constants.h FLD.h  FLD_device.h \
 	pcg_solver.h radmc3d_utils.h star.h timing.h bins.h advection.h \
 	diffusion_device.h sources.h gas1d.h DSHARP_opacs.h file_io.h errorfuncs.h \

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ ARCH=--generate-code arch=compute_60,code=sm_60 \
 
 
 CUDA = nvcc 
-CUDAFLAGS = -O3 -g --std=c++17 -Wno-deprecated-gpu-targets $(ARCH) -lineinfo
+CUDAFLAGS = -O3 -g --std=c++17 -Wno-deprecated-gpu-targets $(ARCH)
 INCLUDE = -I./$(HEADER_DIR) -I$(CUDA_HOME)/include
 
 LIB = -L$(CUDA_HOME)/lib64 -lcudart -lcublas -lcusparse

--- a/src/dustdynamics.cu
+++ b/src/dustdynamics.cu
@@ -367,15 +367,6 @@ void dust_fluxR(GridRef& g, Field3DConstRef<Prims>& w, int i, int j, int k, Fiel
     double rhorat = std::sqrt(w_r[0]/w_l[0]);
     double v_av = (v_l + rhorat * v_r) / (1. + rhorat);
 
-    if (i==g.Nghost && v_av>0.) {
-        fluxR(i,j,k) = {0.,0.,0.,0.};
-        return;
-    } 
-    else if (i==g.NR+g.Nghost && v_av<0.) {
-        fluxR(i,j,k) = {0.,0.,0.,0.};
-        return;
-    }
-
     // Construct fluxes depending on sign of interface velocities
 
     fluxR(i,j,k) = construct_fluxes(v_l, v_r, v_av, w_l, w_r);
@@ -403,15 +394,6 @@ void dust_fluxZ(GridRef& g, Field3DConstRef<Prims>& w, int i, int j, int k, Fiel
 
     double rhorat = std::sqrt(w_r[0]/w_l[0]);
     double v_av = (v_l + rhorat * v_r) / (1. + rhorat);
-
-    if (j==g.Nghost && v_av>0.) {
-        fluxZ(i,j,k) = {0.,0.,0.,0.};
-        return;
-    } 
-    else if (j==g.NR+g.Nghost && v_av<0.) {
-        fluxZ(i,j,k) = {0.,0.,0.,0.};
-        return;
-    }
 
     fluxZ(i,j,k) = construct_fluxes(v_l, v_r, v_av, w_l, w_r);
     if (do_diffusion) 
@@ -443,15 +425,6 @@ void dust_flux_vlR(GridRef& g, Field3DConstRef<Prims>& w, int i, int j, int k, F
 
     double rhorat = std::sqrt(w_r[0]/w_l[0]);
     double v_av = (v_l + rhorat * v_r) / (1. + rhorat);
-
-    if (i==g.Nghost && v_av>0.) {
-        fluxR(i,j,k) = {0.,0.,0.,0.};
-        return;
-    } 
-    else if (i==g.NR+g.Nghost && v_av<0.) {
-        fluxR(i,j,k) = {0.,0.,0.,0.};
-        return;
-    }
 
     // Construct fluxes depending on sign of interface velocities
 
@@ -486,15 +459,6 @@ void dust_flux_vlZ(GridRef& g, Field3DConstRef<Prims>& w, int i, int j, int k, F
 
     double rhorat = std::sqrt(w_r[0]/w_l[0]);
     double v_av = (v_l + rhorat * v_r) / (1. + rhorat);
-
-    if (j==g.Nghost && v_av>0.) {
-        fluxZ(i,j,k) = {0.,0.,0.,0.};
-        return;
-    } 
-    else if (j==g.Nphi+g.Nghost && v_av<0.) {
-        fluxZ(i,j,k) = {0.,0.,0.,0.};
-        return;
-    }
 
     // Construct fluxes depending on sign of interface velocities
 
@@ -629,7 +593,8 @@ __global__ void _set_boundary_flux(GridRef g, int bound, Field3DRef<Quants> flux
 
                 if (i <= g.Nghost) {
                     if (bound & BoundaryFlags::open_R_inner) {  //outflow
-                        continue;
+                        if (fluxR(i,j,k).rho > 0) // prevent inflow
+                            fluxR(i,j,k) = {0.,0.,0.,0.};
                     }
                     else {  //reflecting
                         fluxR(i,j,k) = {0.,0.,0.,0.};
@@ -638,7 +603,8 @@ __global__ void _set_boundary_flux(GridRef g, int bound, Field3DRef<Quants> flux
 
                 if (j>=g.Nphi+g.Nghost) {
                     if (bound & BoundaryFlags::open_Z_outer) {
-                        continue;
+                        if (fluxZ(i,j,k).rho < 0) // prevent inflow
+                            fluxZ(i,j,k) = {0.,0.,0.,0.};
                     }
                     else {
                         fluxZ(i,j,k) = {0.,0.,0.,0.};
@@ -647,7 +613,8 @@ __global__ void _set_boundary_flux(GridRef g, int bound, Field3DRef<Quants> flux
 
                 if (i>=g.NR+g.Nghost) {
                     if (bound & BoundaryFlags::open_R_outer) {
-                        continue;
+                        if (fluxR(i,j,k).rho < 0) // prevent inflow
+                            fluxR(i,j,k) = {0.,0.,0.,0.};
                     }
                     else {
                         fluxR(i,j,k) = {0.,0.,0.,0.};
@@ -656,7 +623,8 @@ __global__ void _set_boundary_flux(GridRef g, int bound, Field3DRef<Quants> flux
                 
                 if (j <= g.Nghost) {
                     if (bound & BoundaryFlags::open_Z_inner) {  
-                        continue;
+                        if (fluxZ(i,j,k).rho > 0) // prevent inflow
+                            fluxZ(i,j,k) = {0.,0.,0.,0.};
                     }
                     else {  
                         fluxZ(i,j,k) = {0.,0.,0.,0.};
@@ -713,6 +681,7 @@ void DustDynamics::operator() (Grid& g, Field3D<Prims>& w_dust, const Field<Prim
         _calc_donor_flux<false><<<blocks,threads>>>(g, w_dust, w_gas, _cs, fluxR, fluxZ, _D, _gas_floor);
 
     // Update quantities a half time step and and source terms.
+    _set_boundary_flux<<<blocks,threads>>>(g, _boundary, fluxR, fluxZ);
     _update_quants<<<blocks,threads>>>(g, q_mids, q, dt/2., fluxR, fluxZ);
     _sources.source_exp(g, w_dust, q_mids, dt/2.);
     _calc_prim<<<blocks,threads>>>(g, q_mids, w_dust);

--- a/src/dustdynamics.cu
+++ b/src/dustdynamics.cu
@@ -491,7 +491,7 @@ void dust_flux_vlZ(GridRef& g, Field3DConstRef<Prims>& w, int i, int j, int k, F
         fluxZ(i,j,k) = {0.,0.,0.,0.};
         return;
     } 
-    else if (j==g.NR+g.Nghost && v_av<0.) {
+    else if (j==g.Nphi+g.Nghost && v_av<0.) {
         fluxZ(i,j,k) = {0.,0.,0.,0.};
         return;
     }

--- a/src/scan.cu
+++ b/src/scan.cu
@@ -78,7 +78,7 @@ __global__ void scan_Z_generic_device(GridRef g, FieldRef<T> f) {
 
     extern __shared__ double tmp[] ;
     tmp[tid] = OP::identity() ;
-
+    
     // Step 1: Reduce work to a block of at most blockDim.xelements.
     int worksize = (g.Nphi + 2*g.Nghost + blockDim.x - 1) / blockDim.x ;
     int i = threadIdx.y + blockIdx.y * blockDim.y ;
@@ -99,7 +99,7 @@ __global__ void scan_Z_generic_device(GridRef g, FieldRef<T> f) {
 
     // Step 2: Perform an exclusive on reduced array:
     scan_block<OP, ScanKind::exclusive,T>
-        (tmp + threadIdx.y*blockDim.x, threadIdx.x) ;
+        (tmp + threadIdx.y*blockDim.x) ;
 
     // Step3: Add the result of step 2 to 1 to get the final result
     for (int k=0; k < worksize; k++) {
@@ -146,7 +146,7 @@ __global__ void scan_R_generic_device(GridRef g, FieldRef<T> f) {
  
     // Step 2: Perform an exclusive on reduced array:
     scan_block<OP, ScanKind::exclusive,T>
-        (tmp + threadIdx.y*blockDim.x, threadIdx.x) ;
+        (tmp + threadIdx.y*blockDim.x) ;
  
     // Step3: Add the result of step 2 to 1 to get the final result
     for (int k=0; k < worksize; k++) {


### PR DESCRIPTION
This branch fixes a bug in the advection routines that could zero out the vertical flux at a specific location in the grid when the number of radial cells is less than the number of vertical ones. The unit tests pass after the fix. I made a couple of incidental changes recommended by the compute-sanitizer too.