### PR TITLE
Caching cell area/volumes

### DIFF
--- a/headers/dustdynamics1D.h
+++ b/headers/dustdynamics1D.h
@@ -17,6 +17,8 @@ struct Prims1D {
     } ;
 } ;
 
+struct Prims ;
+
 template<bool use_full_stokes=false>
 class DustDyn1D {
 

--- a/headers/grid.h
+++ b/headers/grid.h
@@ -154,7 +154,7 @@ class Grid {
     }
     
     double volume(int i, int j) const {
-        return (_V[i+1] - _V[i])* (_tan_theta_e[j+1] - _tan_theta_e[j]);
+        return _V[i]* (_tan_theta_e[j+1] - _tan_theta_e[j]);
     }
 
     // Locations in cylindrical co-ordinates
@@ -232,12 +232,12 @@ class GridRef {
 
     __host__ __device__ 
     double area_Z(int i, int j) const { 
-        return (_Az[i+1] - _Az[i])/_cos_theta_e[j];
+        return _Az[i]/_cos_theta_e[j];
     }
     
     __host__ __device__ 
     double volume(int i, int j) const {
-        return (_V[i+1] - _V[i])* (_tan_theta_e[j+1] - _tan_theta_e[j]);
+        return _V[i]* (_tan_theta_e[j+1] - _tan_theta_e[j]);
     }
 
 

--- a/headers/grid.h
+++ b/headers/grid.h
@@ -143,45 +143,18 @@ class Grid {
     Grid(int NR, int Nphi, int Nghost, 
          CudaArray<double> R, CudaArray<double> phi, int index=-1);
 
-    void set_coord_system(Coords system) {
-        coord_system = system;
-    }
+    void set_coord_system(Coords system) ;
 
     double area_R(int i, int j) const { 
-        switch(coord_system) {
-            case Coords::cart:{
-                return Re(i)*(_tan_theta_e[j+1] - _tan_theta_e[j]);
-            }
-            case Coords::cyl: {
-                return Re(i) * Re(i) * (_tan_theta_e[j+1] - _tan_theta_e[j]) ;
-            }
-            default: __builtin_unreachable();
-        }
+        return _Ar[i]*(_tan_theta_e[j+1] - _tan_theta_e[j]);
     }
 
     double area_Z(int i, int j) const { 
-        switch(coord_system) {
-            case Coords::cart: {
-                return (Re(i+1) - Re(i))/_cos_theta_e[j];
-            }
-            case Coords::cyl: {
-                return 0.5 * (Re(i+1) * Re(i+1) - Re(i) * Re(i)) / _cos_theta_e[j] ;
-            }
-            default: __builtin_unreachable();
-        }
+        return _Az[i]/_cos_theta_e[j];
     }
     
     double volume(int i, int j) const {
-        switch(coord_system) {
-            case Coords::cart: {
-                return 0.5*(Re(i+1)*Re(i+1) - Re(i)*Re(i)) * (_tan_theta_e[j+1] - _tan_theta_e[j]); 
-            }
-            case Coords::cyl: {
-                double dV = (Re(i+1)*Re(i+1)*Re(i+1) - Re(i)*Re(i)*Re(i)) / 3 ;
-                return dV * (_tan_theta_e[j+1] - _tan_theta_e[j]) ;
-            }    
-            default: __builtin_unreachable();
-        }
+        return (_V[i+1] - _V[i])* (_tan_theta_e[j+1] - _tan_theta_e[j]);
     }
 
     // Locations in cylindrical co-ordinates
@@ -217,7 +190,7 @@ class Grid {
     void write_grid(std::filesystem::path) const ;
 
   private:
-    CudaArray<double> _Re, _Rc ;
+    CudaArray<double> _Re, _Rc, _Ar, _Az, _V ;
     CudaArray<double> _sin_theta_e, _sin_theta_c ;
     CudaArray<double> _cos_theta_e, _cos_theta_c ;
     CudaArray<double> _tan_theta_e, _tan_theta_c ;
@@ -246,66 +219,25 @@ class GridRef {
 
     GridRef(const Grid& g)
      : NR(g.NR), Nphi(g.Nphi), Nghost(g.Nghost), index(g.index), coord_system(g.coord_system),
-       _Re(g._Re.get()), _Rc(g._Rc.get()), 
+       _Re(g._Re.get()), _Rc(g._Rc.get()), _Ar(g._Ar.get()), _Az(g._Az.get()), _V(g._V.get()),
        _sin_theta_e(g._sin_theta_e.get()), _sin_theta_c(g._sin_theta_c.get()),
        _cos_theta_e(g._cos_theta_e.get()), _cos_theta_c(g._cos_theta_c.get()),
        _tan_theta_e(g._tan_theta_e.get()), _tan_theta_c(g._tan_theta_c.get())
     { } ;
 
-    // __host__ __device__ 
-    // double area_R(int i, int j) const { 
-    //     //return Re(i)*(_tan_theta_e[j+1] - _tan_theta_e[j]); // cart coords
-    //     return Re(i) * Re(i) * (_tan_theta_e[j+1] - _tan_theta_e[j]) ;
-    // }
-    // __host__ __device__ 
-    // double area_Z(int i, int j) const { 
-    //     //return (Re(i+1) - Re(i))/_cos_theta_e[j]; // cart coords
-    //     return 0.5 * (Re(i+1) * Re(i+1) - Re(i) * Re(i)) / _cos_theta_e[j] ;
-    // }
-    
-    // __host__ __device__ 
-    // double volume(int i, int j) const {
-    //     //return 0.5*(Re(i+1)*Re(i+1) - Re(i)*Re(i)) * (_tan_theta_e[j+1] - _tan_theta_e[j]); // cart coords
-    //     double dV = (Re(i+1)*Re(i+1)*Re(i+1) - Re(i)*Re(i)*Re(i)) / 3 ;
-    //     return dV * (_tan_theta_e[j+1] - _tan_theta_e[j]) ;
-    // }
-
     __host__ __device__ 
     double area_R(int i, int j) const { 
-        switch(coord_system) {
-            case Coords::cart: {
-                return Re(i)*(_tan_theta_e[j+1] - _tan_theta_e[j]);
-            }
-            case Coords::cyl: {
-                return Re(i) * Re(i) * (_tan_theta_e[j+1] - _tan_theta_e[j]) ;
-            } 
-            default: __builtin_unreachable();
-        }
+        return _Ar[i]*(_tan_theta_e[j+1] - _tan_theta_e[j]);
     }
+
     __host__ __device__ 
     double area_Z(int i, int j) const { 
-        switch(coord_system) {
-            case Coords::cart: {
-                return (Re(i+1) - Re(i))/_cos_theta_e[j];
-            }    
-            case Coords::cyl: {
-                return 0.5 * (Re(i+1) * Re(i+1) - Re(i) * Re(i)) / _cos_theta_e[j] ;
-            }  
-            default: __builtin_unreachable();
-        }
+        return (_Az[i+1] - _Az[i])/_cos_theta_e[j];
     }
+    
     __host__ __device__ 
     double volume(int i, int j) const {
-        switch(coord_system) {
-            case Coords::cart: {
-                return 0.5*(Re(i+1)*Re(i+1) - Re(i)*Re(i)) * (_tan_theta_e[j+1] - _tan_theta_e[j]);
-            }    
-            case Coords::cyl: {
-                double dV = (Re(i+1)*Re(i+1)*Re(i+1) - Re(i)*Re(i)*Re(i)) / 3 ;
-                return dV * (_tan_theta_e[j+1] - _tan_theta_e[j]) ;
-            }
-            default: __builtin_unreachable();
-        }
+        return (_V[i+1] - _V[i])* (_tan_theta_e[j+1] - _tan_theta_e[j]);
     }
 
 
@@ -358,7 +290,7 @@ class GridRef {
     double dsin_th(int j) const { return _sin_theta_e[j+1] - _sin_theta_e[j] ;}
 
   private:
-    const double *_Re, *_Rc ;
+    const double *_Re, *_Rc, *_Ar, *_Az, *_V ;
     const double *_sin_theta_e, *_sin_theta_c ;
     const double *_cos_theta_e, *_cos_theta_c ;
     const double *_tan_theta_e, *_tan_theta_c ;

--- a/src/grid.cu
+++ b/src/grid.cu
@@ -33,8 +33,8 @@ Grid::Grid(Grid::params p)
     _Rc = make_CudaArray<double>(NR + 2*Nghost) ;
     _Re = make_CudaArray<double>(NR + 2*Nghost + 1) ;
     _Ar = make_CudaArray<double>(NR + 2*Nghost + 1) ;
-    _Az = make_CudaArray<double>(NR + 2*Nghost + 1) ;
-    _V  = make_CudaArray<double>(NR + 2*Nghost + 1) ;
+    _Az = make_CudaArray<double>(NR + 2*Nghost) ;
+    _V  = make_CudaArray<double>(NR + 2*Nghost) ;
 
 
     switch(p.R_spacing) {
@@ -220,8 +220,8 @@ Grid::Grid(int NR_, int Nphi_, int Nghost_,
     _Rc = make_CudaArray<double>(NR + 2*Nghost) ;
     _Re = std::move(R) ;
     _Ar = make_CudaArray<double>(NR + 2*Nghost + 1) ;
-    _Az = make_CudaArray<double>(NR + 2*Nghost + 1) ;
-    _V  = make_CudaArray<double>(NR + 2*Nghost + 1) ;
+    _Az = make_CudaArray<double>(NR + 2*Nghost) ;
+    _V  = make_CudaArray<double>(NR + 2*Nghost) ;
 
     for (int i=0; i < NR + 2*Nghost; i++) {
         _Rc[i] = centroid(_Re[i], _Re[i+1]) ;
@@ -259,17 +259,19 @@ void Grid::set_coord_system(Coords system) {
     
     switch(coord_system) {
     case Coords::cart:
-        for (int i=0; i < NR + 2*Nghost+1; i++) {
-            _Ar[i] = _Re[i] ;
-            _Az[i] = _Re[i] ;
-            _V[i]  = _Re[i]*_Re[i]/2. ;
+        _Ar[0] = _Re[0] ;
+        for (int i=0; i < NR + 2*Nghost; i++) {
+            _Ar[i+1] = _Re[i+1] ;
+            _Az[ i ] = _Re[i+1] - _Re[i] ;
+            _V [ i ] = (_Re[i+1]*_Re[i+1] - _Re[i]*_Re[i])/2. ;
         }
         break ;
       case Coords::cyl:
-        for (int i=0; i < NR + 2*Nghost+1; i++) {
-            _Ar[i] = _Re[i]*_Re[i] ;
-            _Az[i] = _Re[i]*_Re[i]/2. ;
-            _V[i]  = _Re[i]*_Re[i]*_Re[i]/3. ;
+        _Ar[0] = _Re[0]*_Re[0] ;
+        for (int i=0; i < NR + 2*Nghost; i++) {
+            _Ar[i+1] =  _Re[i+1]*_Re[i+1] ;
+            _Az[ i ] = (_Re[i+1]*_Re[i+1] - _Re[i]*_Re[i])/2. ;
+            _V [ i ] = (_Re[i+1]*_Re[i+1]*_Re[i+1] - _Re[i]*_Re[i]*_Re[i])/3. ;
         }
         break ;
       default: __builtin_unreachable() ;


### PR DESCRIPTION
I had some issues with newer versions of nvcc complaining about calls to __builtin_unreachable() on the GPU. To solve this I've changed the grid code to cache the cell areas/volumes so that we don't need to check the co-ordinate systems anymore.